### PR TITLE
Adds soundcloud regex to embedda

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Currently embedda can embed the following formats:
 
 * Youtube
 * Vimeo
+* Soundcloud
 
 ## Links
 

--- a/lib/embedda.rb
+++ b/lib/embedda.rb
@@ -1,14 +1,17 @@
+require 'cgi'
+
 class String
   def embedda(options = {})
-    options = {:filters => [:youtube, :vimeo]}.merge(options)
+    options = {:filters => [:youtube, :vimeo, :soundcloud]}.merge(options)
 
     # Make sure that filters is an array because we allow the short form of
     # "hello".embedda(:filters => :youtube) instead of "hello".embedda(:filters => [:youtube])
     options[:filters] = Array(options[:filters])
 
     compiled = self
-    compiled = youtube_replace(compiled) if options[:filters].include?(:youtube)
-    compiled = vimeo_replace(compiled)   if options[:filters].include?(:vimeo)
+    compiled = youtube_replace(compiled)    if options[:filters].include?(:youtube)
+    compiled = vimeo_replace(compiled)      if options[:filters].include?(:vimeo)
+    compiled = soundcloud_replace(compiled) if options[:filters].include?(:soundcloud)
 
     return compiled
   end
@@ -32,5 +35,19 @@ class String
   end
   def vimeo_player(token)
     "<iframe src=\"http://player.vimeo.com/video/#{token}\" width=\"500\" height=\"281\" frameborder=\"0\" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>"
+  end
+
+  def soundcloud_replace(compiled)
+    r = /(https?:\/\/(?:www.)?soundcloud.com\/[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*(?!\/sets(?:\/|$))(?:\/[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*){1,2}\/?)/i
+    compiled.gsub!(r) { |match| soundcloud_player(match) }
+
+    return compiled
+  end
+
+  def soundcloud_player(token)
+    url_encoded_string = CGI::escape(token)
+
+    # Note: added '&' ...?url=...&
+    "<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?url=#{url_encoded_string}&color=ff6600&amp;auto_play=false&amp;show_artwork=false\"></iframe>"
   end
 end

--- a/spec/embedda_spec.rb
+++ b/spec/embedda_spec.rb
@@ -63,7 +63,7 @@ describe "Embedda" do
       expect(story).to eq("Hello, my name is Kasper: #{@embed_string}<br/>And I am embedding links")
     end
 
-    it "should embed when text include anchor tag to Youtube" do
+    it "should embed when text include anchor tag to Vimeo" do
       story = "<a href=\"http://vimeo.com/20241459\">Look here for HalfLife3!</a>".embedda
       expect(story).to eq(@embed_string)
     end
@@ -82,6 +82,32 @@ describe "Embedda" do
       story = "Hello, my name is Kasper: <a href=\"http://vimeo.com/20241459\">Look here for HalfLife3!</a><br/>And I am embedding links".embedda(:filters => :youtube)
       expect(story).to eq("Hello, my name is Kasper: <a href=\"http://vimeo.com/20241459\">Look here for HalfLife3!</a><br/>And I am embedding links")
     end
+  end
 
+  context "Soundcloud-link" do
+    before(:all) do
+      @embed_string = "<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false\"></iframe>"
+      @link         = "https://soundcloud.com/flume-1/flume-left-alone-bobby-tank"
+    end
+
+    it "should embed when text have a link" do
+      story = @link.embedda
+      expect(story).to eq(@embed_string)
+    end
+
+    it "should embed when also other text is present around link" do
+      story = "Hello, my name is Takle: #{@link}<br/>And I am embedding links".embedda
+      expect(story).to eq("Hello, my name is Takle: #{@embed_string}<br/>And I am embedding links")
+    end
+
+    it "should embed when enabled" do
+      story = "Hello, my name is Takle: #{@link}<br/>And I am embedding links".embedda(:filters => :soundcloud)
+      expect(story).to eq("Hello, my name is Takle: #{@embed_string}<br/>And I am embedding links")
+    end
+
+    it "should not embed when disabled" do
+      story = "Hello, my name is Takle: #{@link}<br/>And I am not embedding links".embedda(:filters => :youtube)
+      expect(story).to eq("Hello, my name is Takle: #{@link}<br/>And I am not embedding links")
+    end
   end
 end


### PR DESCRIPTION
# Adds Soundcloud

The spec is updated to reflect the new functionallity
## Limitation

Currently to soundcloud feature doens't support

``` html
<a href="soundcloud-track-url"> Link to awesome track </a>
```
### Issues

I hit some weird issues when implementing the regex the same way as the existing features, created a question on stackoverflow for it.
http://stackoverflow.com/questions/15913567/escaping-matched-result-from-regex
