### PR TITLE
Improves robustness and small refactor

### DIFF
--- a/lib/embedda.rb
+++ b/lib/embedda.rb
@@ -1,5 +1,6 @@
 require 'cgi'
 require 'helpers/url_regex'
+require 'helpers/soundcloud_regex'
 
 class Embedda
   class UnknownFilter < StandardError
@@ -49,28 +50,8 @@ class Embedda
   end
 
   def soundcloud_replace(compiled)
-    # Known URL's
-    #   https://soundcloud.com/:user/:tracks
-    #   https://soundcloud.com/:user/sets/:tracks
-    url_re = / # Match Soundcloud track or sets URL
-              (                        # Capture Group
-                #{Regex::URL[:scheme]} # URL scheme
-                soundcloud.com\/       #
-                [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
-                \/                     # slash
-                (?:sets\/)?            # Optional sets-slash                  non-capturing group
-                [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
-              )
-              /ix
-
-    link_re = / # Match Soundcloud a-tag with track or sets URL
-              <a.+        # Start of HTML anchor-tag plus random characters
-                #{url_re}
-              .+<\/a>     # Random characters plus end of HTML anchor-tag
-              /ix
-
-    compiled.gsub!(link_re) { |m| $1 }                   # Substitute anchor-tags with soundcloud URL's
-    compiled.gsub!(url_re)  { |m| soundcloud_player(m) } # Substitute URL's with soundcloud_player
+    compiled.gsub!(Regex::Soundcloud[:anchor]) { |m| $1 }                   # Substitute anchor-tags with soundcloud URL's
+    compiled.gsub!(Regex::Soundcloud[:url])    { |m| soundcloud_player(m) } # Substitute URL's with soundcloud_player
 
     return compiled
   end

--- a/lib/embedda.rb
+++ b/lib/embedda.rb
@@ -52,22 +52,29 @@ class Embedda
     # Known URL's
     #   https://soundcloud.com/:user/:tracks
     #   https://soundcloud.com/:user/sets/:tracks
-    re = / # Match Soundcloud track or sets URL
-          (                        # Capture Group
-            (?<!'|")               # Negative lookbehind assertion, prevents href matching
-            #{Regex::URL[:scheme]} # URL scheme
-            soundcloud.com\/       #
-            [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
-            \/                     # slash
-            (?:sets\/)?            # Optional sets-slash                  non-capturing group
-            [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
-          )
-        /ix
+    url_re = / # Match Soundcloud track or sets URL
+              (                        # Capture Group
+                #{Regex::URL[:scheme]} # URL scheme
+                soundcloud.com\/       #
+                [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+                \/                     # slash
+                (?:sets\/)?            # Optional sets-slash                  non-capturing group
+                [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+              )
+              /ix
 
-    compiled.gsub!(re) { |m| soundcloud_player(m) }
+    link_re = / # Match Soundcloud a-tag with track or sets URL
+              <a.+        # Start of HTML anchor-tag plus random characters
+                #{url_re}
+              .+<\/a>     # Random characters plus end of HTML anchor-tag
+              /ix
+
+    compiled.gsub!(link_re, '/1')                       # Substitute anchor-tags with soundcloud URL's
+    compiled.gsub!(url_re) { |m| soundcloud_player(m) } # Substitute URL's with soundcloud_player
 
     return compiled
   end
+
   def soundcloud_player(token)
     url_encoded_string = CGI::escape(token)
 

--- a/lib/embedda.rb
+++ b/lib/embedda.rb
@@ -69,8 +69,8 @@ class Embedda
               .+<\/a>     # Random characters plus end of HTML anchor-tag
               /ix
 
-    compiled.gsub!(link_re, '/1')                       # Substitute anchor-tags with soundcloud URL's
-    compiled.gsub!(url_re) { |m| soundcloud_player(m) } # Substitute URL's with soundcloud_player
+    compiled.gsub!(link_re) { |m| $1 }                   # Substitute anchor-tags with soundcloud URL's
+    compiled.gsub!(url_re)  { |m| soundcloud_player(m) } # Substitute URL's with soundcloud_player
 
     return compiled
   end

--- a/lib/embedda.rb
+++ b/lib/embedda.rb
@@ -1,4 +1,5 @@
 require 'cgi'
+require 'helpers/url_regex'
 
 class Embedda
   class UnknownFilter < StandardError
@@ -14,7 +15,7 @@ class Embedda
   end
 
   def embed
-    return if @string.to_s.empty?
+    return @string if @string.to_s.empty?
     @filters.each do |filter_name|
       begin
         @string = send("#{filter_name}_replace", @string)
@@ -29,7 +30,7 @@ class Embedda
 
   def youtube_replace(compiled)
     compiled.gsub!(/(<a[^>]*?youtube\.com\/watch\?v=([a-zA-Z0-9\-\_]+).*?<\/a>)/i) { |m| youtube_player($2) }
-    compiled.gsub!(/([http|https]+:\/\/(?:www\.)?youtube\.com\/watch\?v=([a-zA-Z0-9\-\_]+)\w*)/i) { |m| youtube_player($2) }
+    compiled.gsub!(/(#{Regex::URL[:scheme]}youtube\.com\/watch\?v=([a-zA-Z0-9\-\_]+)\w*)/i) { |m| youtube_player($2) }
 
     return compiled
   end
@@ -39,7 +40,7 @@ class Embedda
 
   def vimeo_replace(compiled)
     compiled.gsub!(/(<a[^>]*?vimeo\.com\/(\d+).*?<\/a>)/i) { |m| vimeo_player($2) }
-    compiled.gsub!(/([http|https]+:\/\/(?:www\.)?vimeo\.com\/(\d+)\w*)/i) { |m| vimeo_player($2) }
+    compiled.gsub!(/(#{Regex::URL[:scheme]}vimeo\.com\/(\d+)\w*)/i) { |m| vimeo_player($2) }
 
     return compiled
   end
@@ -48,15 +49,29 @@ class Embedda
   end
 
   def soundcloud_replace(compiled)
-    r = /(https?:\/\/(?:www.)?soundcloud.com\/[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*(?!\/sets(?:\/|$))(?:\/[A-Za-z0-9]+(?:[-_][A-Za-z0-9]+)*){1,2}\/?)/i
-    compiled.gsub!(r) { |m| soundcloud_player(m) }
+    # Known URL's
+    #   https://soundcloud.com/:user/:tracks
+    #   https://soundcloud.com/:user/sets/:tracks
+    re = / # Match Soundcloud track or sets URL
+          (                        # Capture Group
+            (?<!'|")               # Negative lookbehind assertion, prevents href matching
+            #{Regex::URL[:scheme]} # URL scheme
+            soundcloud.com\/       #
+            [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+            \/                     # slash
+            (?:sets\/)?            # Optional sets-slash                  non-capturing group
+            [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+          )
+        /ix
+
+    compiled.gsub!(re) { |m| soundcloud_player(m) }
 
     return compiled
   end
   def soundcloud_player(token)
     url_encoded_string = CGI::escape(token)
 
-    # Note: added '&' ...?url=...&
+    # Note: changed ';' to '&'  ...?url=...&
     "<iframe width=\"100%\" height=\"166\" scrolling=\"no\" frameborder=\"no\" src=\"https://w.soundcloud.com/player/?url=#{url_encoded_string}&color=ff6600&amp;auto_play=false&amp;show_artwork=false\"></iframe>"
   end
 end

--- a/lib/helpers/soundcloud_regex.rb
+++ b/lib/helpers/soundcloud_regex.rb
@@ -1,0 +1,23 @@
+require 'helpers/url_regex'
+
+module Regex
+  # Known URL's
+  #   https://soundcloud.com/:user/:tracks
+  #   https://soundcloud.com/:user/sets/:tracks
+  Soundcloud = { :url => / # Match Soundcloud track or sets URL
+                         (                        # Capture Group
+                           #{Regex::URL[:scheme]} # URL scheme
+                           soundcloud.com\/       #
+                           [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+                           \/                     # slash
+                           (?:sets\/)?            # Optional sets-slash                  non-capturing group
+                           [A-Za-z0-9_-]+         # One or more word character, underscore and dash included
+                         )
+                         /ix }
+
+  Soundcloud[:anchor] = / # Match Soundcloud a-tag with track or sets URL
+                           <a.+                 # Start of HTML anchor-tag plus random characters
+                            #{Soundcloud[:url]}
+                           .+<\/a>              # Random characters plus end of HTML anchor-tag
+                           /ix
+end

--- a/lib/helpers/url_regex.rb
+++ b/lib/helpers/url_regex.rb
@@ -4,9 +4,12 @@ module Regex
   #     ...http://...
   #     ...https://...
   #   where ... is arbitrary text
-  URL = { :scheme => / # Match a Uniform Resource Locator scheme
-                       (?:http|https) # http or https       non-capturing group
-                       :\/\/          # colon-slash-slash
-                       (?:www\.)?     # Optional www.       non-capturing group
-                     /x }
+  # URL = { :scheme => / # Match a Uniform Resource Locator scheme
+  #                      (?:http|https) # http or https       non-capturing group
+  #                      :\/\/          # colon-slash-slash
+  #                      (?:www\.)?     # Optional www.       non-capturing group
+  #                    /x }
+
+  # 1.8.7 and ree doesn't support the above syntax
+  URL = { :scheme => /(?:http|https):\/\/(?:www\.)?/ }
 end

--- a/lib/helpers/url_regex.rb
+++ b/lib/helpers/url_regex.rb
@@ -1,0 +1,12 @@
+module Regex
+  # Info
+  #   This will match
+  #     ...http://...
+  #     ...https://...
+  #   where ... is arbitrary text
+  URL = { :scheme => / # Match a Uniform Resource Locator scheme
+                       (?:http|https) # http or https       non-capturing group
+                       :\/\/          # colon-slash-slash
+                       (?:www\.)?     # Optional www.       non-capturing group
+                     /x }
+end

--- a/lib/helpers/url_regex.rb
+++ b/lib/helpers/url_regex.rb
@@ -4,12 +4,9 @@ module Regex
   #     ...http://...
   #     ...https://...
   #   where ... is arbitrary text
-  # URL = { :scheme => / # Match a Uniform Resource Locator scheme
-  #                      (?:http|https) # http or https       non-capturing group
-  #                      :\/\/          # colon-slash-slash
-  #                      (?:www\.)?     # Optional www.       non-capturing group
-  #                    /x }
-
-  # 1.8.7 and ree doesn't support the above syntax
-  URL = { :scheme => /(?:http|https):\/\/(?:www\.)?/ }
+  URL = { :scheme => / # Match a Uniform Resource Locator scheme
+                       (?:http|https) # http or https       non-capturing group
+                       :\/\/          # colon-slash-slash
+                       (?:www\.)?     # Optional www.       non-capturing group
+                     /x }
 end

--- a/spec/embedda_spec.rb
+++ b/spec/embedda_spec.rb
@@ -87,33 +87,6 @@ describe Embedda do
     end
   end
 
-  context "Soundcloud-link" do
-    let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
-    let(:link)         { 'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank' }
-
-    it "should embed when text have a link" do
-      @story = link
-      expect(embedda).to eq(embed_string)
-    end
-
-    it "should embed when also other text is present around link" do
-      @story = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
-      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
-    end
-
-    it "should embed when enabled" do
-      @story  = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
-      embedda = described_class.new(@story, :filters => :soundcloud).embed
-      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
-    end
-
-    it "should not embed when disabled" do
-      @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
-      embedda = described_class.new(@story, :filters => :youtube).embed
-      expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
-    end
-  end
-
   context "All embeds in one string" do
       let(:youtube)         { '<iframe width="560" height="315" src="http://www.youtube.com/embed/dQw4w9WgXcQ" frameborder="0" allowfullscreen></iframe>' }
       let(:youtube_link)    { 'http://www.youtube.com/watch?v=dQw4w9WgXcQ' }
@@ -149,5 +122,4 @@ describe Embedda do
       expect { described_class.new(story, :filters => [:dummy]).embed }.to raise_error(Embedda::UnknownFilter)
     end
   end
-
 end

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -7,8 +7,6 @@ describe Embedda do
   context "Soundcloud-link" do
     let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
     let(:link)         { 'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank' }
-    let(:href_single)  { '<a href=\'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank\'>Soundcloud</a>' }
-    let(:href_double)  { '<a href="https://soundcloud.com/flume-1/flume-left-alone-bobby-tank">Soundcloud</a>' }
 
     it "should embed when text have a link" do
       @story = link
@@ -30,24 +28,12 @@ describe Embedda do
       @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
       embedda = described_class.new(@story, :filters => :youtube).embed
       expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
-    end
-
-    it "should not embed inside double quote href=\"URL\"" do
-      @story  = "Hello, my name is Takle: #{href_double}<br/>And I am not embedding links"
-      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\"#{embed_string}\">Soundcloud</a><br/>And I am not embedding links")
-    end
-
-    it "should not embed inside single quote href=\'URL\'" do
-      @story  = "Hello, my name is Takle: #{href_single}<br/>And I am not embedding links"
-      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\'#{embed_string}\'>Soundcloud</a><br/>And I am not embedding links")
     end
   end
 
   context "Soundcloud-sets-link" do
     let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Ftekktv%2Fsets%2Fdj-mix-sets&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
     let(:link)         { 'https://soundcloud.com/tekktv/sets/dj-mix-sets' }
-    let(:href_single)  { '<a href=\'https://soundcloud.com/tekktv/sets/dj-mix-sets\'>Soundcloud</a>' }
-    let(:href_double)  { '<a href="https://soundcloud.com/tekktv/sets/dj-mix-sets">Soundcloud</a>' }
 
     it "should embed when text have a link" do
       @story = link
@@ -69,16 +55,6 @@ describe Embedda do
       @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
       embedda = described_class.new(@story, :filters => :youtube).embed
       expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
-    end
-
-    it "should not embed inside double quote href=\"URL\"" do
-      @story  = "Hello, my name is Takle: #{href_double}<br/>And I am not embedding links"
-      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\"#{embed_string}\">Soundcloud</a><br/>And I am not embedding links")
-    end
-
-    it "should not embed inside single quote href=\'URL\'" do
-      @story  = "Hello, my name is Takle: #{href_single}<br/>And I am not embedding links"
-      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\'#{embed_string}\'>Soundcloud</a><br/>And I am not embedding links")
     end
   end
 end

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -60,7 +60,7 @@ describe Embedda do
     end
   end
 
-context "Soundcloud-sets-anchor-link" do
+  context "Soundcloud-sets-anchor-link" do
     let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Ftekktv%2Fsets%2Fdj-mix-sets&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
     let(:link)         { '<a href="https://soundcloud.com/tekktv/sets/dj-mix-sets">Soundcloud</a>' }
 

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -1,0 +1,84 @@
+require "spec_helper"
+require "embedda"
+
+describe Embedda do
+  let(:embedda) { described_class.new(@story).embed }
+
+  context "Soundcloud-link" do
+    let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
+    let(:link)         { 'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank' }
+    let(:href_single)  { '<a href=\'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank\'>Soundcloud</a>' }
+    let(:href_double)  { '<a href="https://soundcloud.com/flume-1/flume-left-alone-bobby-tank">Soundcloud</a>' }
+
+    it "should embed when text have a link" do
+      @story = link
+      expect(embedda).to eq(embed_string)
+    end
+
+    it "should embed when also other text is present around link" do
+      @story = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should embed when enabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      embedda = described_class.new(@story, :filters => :soundcloud).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should not embed when disabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
+      embedda = described_class.new(@story, :filters => :youtube).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
+    end
+
+    it "should not embed inside double quote href=\"URL\"" do
+      @story  = "Hello, my name is Takle: #{href_double}<br/>And I am not embedding links"
+      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\"#{embed_string}\">Soundcloud</a><br/>And I am not embedding links")
+    end
+
+    it "should not embed inside single quote href=\'URL\'" do
+      @story  = "Hello, my name is Takle: #{href_single}<br/>And I am not embedding links"
+      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\'#{embed_string}\'>Soundcloud</a><br/>And I am not embedding links")
+    end
+  end
+
+  context "Soundcloud-sets-link" do
+    let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Ftekktv%2Fsets%2Fdj-mix-sets&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
+    let(:link)         { 'https://soundcloud.com/tekktv/sets/dj-mix-sets' }
+    let(:href_single)  { '<a href=\'https://soundcloud.com/tekktv/sets/dj-mix-sets\'>Soundcloud</a>' }
+    let(:href_double)  { '<a href="https://soundcloud.com/tekktv/sets/dj-mix-sets">Soundcloud</a>' }
+
+    it "should embed when text have a link" do
+      @story = link
+      expect(embedda).to eq(embed_string)
+    end
+
+    it "should embed when also other text is present around link" do
+      @story = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should embed when enabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      embedda = described_class.new(@story, :filters => :soundcloud).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should not embed when disabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
+      embedda = described_class.new(@story, :filters => :youtube).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
+    end
+
+    it "should not embed inside double quote href=\"URL\"" do
+      @story  = "Hello, my name is Takle: #{href_double}<br/>And I am not embedding links"
+      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\"#{embed_string}\">Soundcloud</a><br/>And I am not embedding links")
+    end
+
+    it "should not embed inside single quote href=\'URL\'" do
+      @story  = "Hello, my name is Takle: #{href_single}<br/>And I am not embedding links"
+      expect(embedda).to_not eq("Hello, my name is Takle: <a href=\'#{embed_string}\'>Soundcloud</a><br/>And I am not embedding links")
+    end
+  end
+end

--- a/spec/soundcloud_spec.rb
+++ b/spec/soundcloud_spec.rb
@@ -1,12 +1,69 @@
+require "pry"
 require "spec_helper"
 require "embedda"
 
 describe Embedda do
   let(:embedda) { described_class.new(@story).embed }
 
+
+  context "Soundcloud-anchor-link" do
+    let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
+    let(:link)         { '<a href="https://soundcloud.com/flume-1/flume-left-alone-bobby-tank">Soundcloud</a>' }
+
+    it "should embed when text have a link" do
+      @story = link
+      expect(embedda).to eq(embed_string)
+    end
+
+    it "should embed when also other text is present around link" do
+      @story = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should embed when enabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      embedda = described_class.new(@story, :filters => :soundcloud).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should not embed when disabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
+      embedda = described_class.new(@story, :filters => :youtube).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
+    end
+  end
+
   context "Soundcloud-link" do
     let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Fflume-1%2Fflume-left-alone-bobby-tank&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
     let(:link)         { 'https://soundcloud.com/flume-1/flume-left-alone-bobby-tank' }
+
+    it "should embed when text have a link" do
+      @story = link
+      expect(embedda).to eq(embed_string)
+    end
+
+    it "should embed when also other text is present around link" do
+      @story = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should embed when enabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am embedding links"
+      embedda = described_class.new(@story, :filters => :soundcloud).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{embed_string}<br/>And I am embedding links")
+    end
+
+    it "should not embed when disabled" do
+      @story  = "Hello, my name is Takle: #{link}<br/>And I am not embedding links"
+      embedda = described_class.new(@story, :filters => :youtube).embed
+      expect(embedda).to eq("Hello, my name is Takle: #{link}<br/>And I am not embedding links")
+    end
+  end
+
+context "Soundcloud-sets-anchor-link" do
+    let(:embed_string) { '<iframe width="100%" height="166" scrolling="no" frameborder="no" src="https://w.soundcloud.com/player/?url=https%3A%2F%2Fsoundcloud.com%2Ftekktv%2Fsets%2Fdj-mix-sets&color=ff6600&amp;auto_play=false&amp;show_artwork=false"></iframe>' }
+    let(:link)         { '<a href="https://soundcloud.com/tekktv/sets/dj-mix-sets">Soundcloud</a>' }
+
 
     it "should embed when text have a link" do
       @story = link

--- a/spec/url_regex_spec.rb
+++ b/spec/url_regex_spec.rb
@@ -1,0 +1,49 @@
+require "spec_helper"
+require "helpers/url_regex"
+
+describe Regex do
+  let(:regex) { Regex::URL[:scheme] }
+
+  context "Scheme" do
+    let(:scheme) { 'http://' }
+
+    it "should match http://" do
+      expect(regex.match(scheme)).to be_true
+    end
+
+    it "should match https://" do
+      expect(regex.match(scheme)).to be_true
+    end
+  end
+
+  context "HTTP scheme with mistakes" do
+    let(:scheme_typo_1) { 'htttp://' }
+    let(:scheme_typo_2) { 'http:://' }
+    let(:scheme_typo_3) { 'httpp://' }
+
+
+    it "should not match typos" do
+      expect(regex.match(scheme_typo_1)).to be_false
+    end
+
+    it "should not match typos" do
+      expect(regex.match(scheme_typo_2)).to be_false
+    end
+
+    it "should not match typos" do
+      expect(regex.match(scheme_typo_3)).to be_false
+    end
+  end
+
+  context "Scheme with www." do
+    let(:scheme) { 'http://www.' }
+
+    it "should match http://www." do
+      expect(regex.match(scheme)).to be_true
+    end
+
+    it "should match https://www." do
+      expect(regex.match(scheme)).to be_true
+    end
+  end
+end


### PR DESCRIPTION
## Update
### TODO
- [ ] Need to add specs to soundcloud anchor substitution
- [ ] Add `o` flag to regex that uses #{...}

`o` Substitute once. Any #{...} substitutions in a particular regular expression literal will be performed just once, the first time it is evaluated. Otherwise, the substitutions will be performed every time the literal generates a Regexp object. 
### Whats new

I discovered an error in the current url scheme regex

``` regex
[http|https]+
```

Gets alot of false positives e.g.
http://rubular.com/r/QbD4dVJYIg

I added a Regex::URL[:scheme] helper to make the code more DRY

I've added tests to support the changes - it would be an idea to add more regex helpers and test them before testing the final output from embedda.
